### PR TITLE
プレイヤーの最大HPを30に変更

### DIFF
--- a/src/Player.ts
+++ b/src/Player.ts
@@ -6,7 +6,7 @@ import { Bullet } from "./Bullet";
 import { emmitDamageEffect } from "./emmitDamageEffect";
 
 export class Player {
-    static MAX_HP = 10; // プレイヤー最大HP
+    static MAX_HP = 30; // プレイヤー最大HP 10->30に変更
 
     private obstacles: number[];
     private type: EntityType;


### PR DESCRIPTION
### 変更点
- プレイヤーの最大HPを30に変更

### その他
**※このPRは改造記事用のものなのでマージ禁止**